### PR TITLE
Implementing a fallback acquirer certificate.

### DIFF
--- a/src/lib/IDeal.php
+++ b/src/lib/IDeal.php
@@ -55,6 +55,11 @@ class IDeal
     private $acquirerCertificate;
 
     /**
+     * @var string Fallback Acquirer certificate (PKCS string representation)
+     */
+    private $fallbackAcquirerCertificate;
+
+    /**
      * @var string Base URL endpoint (unified for all request types)
      */
     private $baseUrl;
@@ -161,6 +166,18 @@ class IDeal
     {
         $this->acquirerCertificate = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, ['type' => 'public']);
         $this->acquirerCertificate->loadKey($key, $isFile, true);
+    }
+
+    /**
+     * Sets acquirer fallback certificate
+     *
+     * @param      $key
+     * @param bool $isFile
+     */
+    public function setFallbackAcquirerCertificate($key, $isFile = true)
+    {
+        $this->fallbackAcquirerCertificate = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, ['type' => 'public']);
+        $this->fallbackAcquirerCertificate->loadKey($key, $isFile, true);
     }
 
     /**
@@ -300,6 +317,16 @@ class IDeal
     }
 
     /**
+     * Return merchant acquirer fallback certificate
+     *
+     * @return string
+     */
+    public function getFallbackAcquirerCertificate()
+    {
+        return $this->fallbackAcquirerCertificate;
+    }
+
+    /**
      * Return base URL
      *
      * @return string
@@ -408,6 +435,14 @@ class IDeal
             $parameters['acquirerCertificate'],
             !$this->isPkcsFormat($parameters['acquirerCertificate'])
         );
+
+        if (!empty($parameters['fallbackAcquirerCertificate'])) {
+            $this->setFallbackAcquirerCertificate(
+                $parameters['fallbackAcquirerCertificate'],
+                !$this->isPkcsFormat($parameters['fallbackAcquirerCertificate'])
+            );
+        }
+
         $this->setMerchant(
             $parameters['merchantId'],
             $parameters['merchantSubId']


### PR DESCRIPTION
If you have to implement a new acquirer certificate, some transactions could fail because only one certificate is allowed in this tool.

By implementing this fallback acquirer certificate, the system is able to migrate from the old acquirer certificate to the a new acquirer certificate. When the first verification fails (with the old acquirer certificate) and a fallbackAcquirerCertificate is set, the fallbackAcquirerCertificate will be used again in order to verify the same request.

Possible way to implement a new acquirer certificate:
- Request a new transaction with the old certificate.
- Add the new received acquirer certificate from your acquirer and add this to the fallbackAcquirerCertificate-option.
- Request a new transaction again to check if everything still works the same.
- Go to the acquirer dashboard turn over to the new certificate.
- Request a new transaction again to test that the request is working. You'll not see any notifications that it is using the fallbackAcquirerCertificate.
- Replace the acquirerCertificate by your fallbackAcquirerCertificate
- Remove the fallbackAcquirerCertificate
