### PR TITLE
Handle connectivity errors

### DIFF
--- a/src/lib/Exception/ConnectionException.php
+++ b/src/lib/Exception/ConnectionException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace CMPayments\IDeal\Exception;
+
+/**
+ * Class ConnectionException
+ * @package CMPayments\IDeal\Exception
+ */
+class ConnectionException extends IDealException
+{
+
+}

--- a/src/lib/IDeal.php
+++ b/src/lib/IDeal.php
@@ -597,6 +597,10 @@ class IDeal
             $response = str_ireplace("HTTP/1.1 100 Continue\r\n\r\n", '', $response);
         }
 
+        if (curl_errno($curl)) {
+            throw new Exception\ConnectionException(curl_error($curl), curl_errno($curl));
+        }
+
         // Split headers and body:
         list($headers, $body) = explode("\r\n\r\n", $response, 2);
 


### PR DESCRIPTION
When cURL returns with an error instead of a response, a meaningfull
exception must be thrown (instead of assuming a response with headers
and a body)