### PR TITLE
Fix #3: getMessage() return empty strings

### DIFF
--- a/src/lib/Exception/NoSuccessException.php
+++ b/src/lib/Exception/NoSuccessException.php
@@ -22,6 +22,8 @@ class NoSuccessException extends IDealException
      */
     public function __construct(Response $response)
     {
+        parent::__construct('iDEAL payment was not successful');
+
         $this->response = $response;
     }
 

--- a/src/lib/Exception/ResponseException.php
+++ b/src/lib/Exception/ResponseException.php
@@ -22,6 +22,8 @@ class ResponseException extends IDealException
      */
     public function __construct(ErrorResponse $response)
     {
+        parent::__construct('Invalid response: ' . $response->getErrorCode() . ' - ' . $response->getErrorMessage());
+
         $this->response = $response;
     }
 


### PR DESCRIPTION
ResponseException::getMessage() and NoSuccessException::getMessage() return
empty strings, which makes logging and debugging more difficult.