### PR TITLE
Encode / escape values that are added to XML doc

### DIFF
--- a/src/lib/Request/Request.php
+++ b/src/lib/Request/Request.php
@@ -111,11 +111,15 @@ class Request
      */
     protected function createElement($name, $value = null)
     {
-        if ($value === null) {
-            $element = $this->doc->createElementNS(self::XMLNS, $name);
-        } else {
-            $element = $this->doc->createElementNS(self::XMLNS, $name, $value);
+        // Always create the element without value, because createElementNS() does not apply encoding / escaping to the value
+        $element = $this->doc->createElementNS(self::XMLNS, $name);
+
+        //  If there is a value, use textContent to set the value;
+        //  textContent is some wierd pseudo-property that does encoding and escaping.
+        if ($value !== null) {
+            $element->textContent = $value;
         }
+
         return $element;
     }
 


### PR DESCRIPTION
If a value is set on a Request that contains a character that has a
special meaning in XML, DOMDocument::createElementNS() triggers an error
if that value is passed in unhandled.

To handle this, instead of passing the value to createElementNS(),
it is let a bit later using the textContent property. This property
takes care of the encoding and escaping for us.

Fixes #5 Descriptions with a & cause a crash